### PR TITLE
Update shooter & targets to look like stick figures

### DIFF
--- a/lib/bullet.js
+++ b/lib/bullet.js
@@ -1,6 +1,6 @@
 function Bullet(directionX, directionY, context) {
-  this.x = 75;
-  this.y = 450;
+  this.x = 80;
+  this.y = 470;
   this.height = 3;
   this.width = 3;
   this.radius = 4;
@@ -13,7 +13,7 @@ function Bullet(directionX, directionY, context) {
 Bullet.prototype.draw = function () {
   this.context.beginPath();
   this.context.arc(this.x, this.y, this.radius, 2 * Math.PI, false);
-  this.context.fillStyle = "#a0a0a0";
+  this.context.fillStyle = "#b5b5b5";
   this.context.fill();
 
   return this;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,14 +6,12 @@ var Bullet = require('./bullet');
 var Shooter = require('./shooter');
 var shooter = new Shooter(context);
 var LevelOne = require('./level_one');
+
 var bullets = [];
 var ammo = 5;
 var level = 1;
 
-if(level === 1){
-  var currentLevel = new LevelOne(context);
-}
-
+if (level === 1) { var currentLevel = new LevelOne(context); }
 
 
 canvas.addEventListener('click', function (target) {

--- a/lib/level_one.js
+++ b/lib/level_one.js
@@ -2,13 +2,13 @@ var Obstacle = require('./obstacle');
 var Target = require('./target');
 
 function LevelOne(context){
-  var obstacleMidVert = new Obstacle(350, 100, 10, 200, context);
-  var obstacleMidHoriz = new Obstacle(550, 200, 200, 10, context);
-  var obstacleEdgeVert = new Obstacle(850, 300, 10, 200, context);
-  var obstacleEdgeHoriz = new Obstacle(0, 200, 200, 10, context);
-  var targetRight = new Target(1093, 100, 7, 50, context);
-  var targetLeft = new Target(0, 90, 7, 50, context);
-  var targetMid = new Target(650, 150, 7, 50, context);
+  var obstacleMidVert = new Obstacle(350, 100, 20, 200, context);
+  var obstacleMidHoriz = new Obstacle(550, 200, 200, 15, context);
+  var obstacleEdgeVert = new Obstacle(850, 300, 25, 200, context);
+  var obstacleEdgeHoriz = new Obstacle(0, 200, 200, 15, context);
+  var targetRight = new Target(850, 250, context);
+  var targetLeft = new Target(0, 150, context);
+  var targetMid = new Target(650, 150, context);
   this.context = context;
   this.score = 0;
   this.targets = [targetRight, targetLeft, targetMid];

--- a/lib/obstacle.js
+++ b/lib/obstacle.js
@@ -7,12 +7,9 @@ function Obstacle(x, y, width, height, context) {
 }
 
 Obstacle.prototype.draw = function () {
-
   var img = new Image();
   img.src = 'http://bgfons.com/upload/brick_texture3348.jpg';
-
   this.context.drawImage(img, this.x, this.y, this.width, this.height);
-  return this;
 };
 
 module.exports = Obstacle;

--- a/lib/shooter.js
+++ b/lib/shooter.js
@@ -1,14 +1,18 @@
 function Shooter(context) {
-  this.x = 70;
-  this.y = 450;
-  this.height = 50;
-  this.width = 10;
+  // this.x = 70;
+  // this.y = 450;
+  // this.height = 50;
+  // this.width = 10;
   this.context = context;
 }
 
 Shooter.prototype.draw = function () {
-  this.context.fillStyle = "#686868";
-  this.context.fillRect(this.x, this.y, this.width, this.height);
+  var img = new Image();
+  img.src = 'http://i.imgur.com/sojxivK.png';
+  this.context.drawImage(img, 70, 450);
+
+  // this.context.fillStyle = "#e1ecf6";
+  // this.context.fillRect(this.x, this.y, this.width, this.height);
 };
 
 module.exports = Shooter;

--- a/lib/target.js
+++ b/lib/target.js
@@ -1,16 +1,17 @@
-function Target(x, y, width, height, context) {
+function Target(x, y, context) {
   this.x = x;
   this.y = y;
-  this.width = width;
-  this.height = height;
+  this.width = 25;
+  this.height = 50;
   this.context = context;
   this.display = true;
 }
 
 Target.prototype.draw = function () {
   if(this.display) {
-    this.context.fillStyle = "red";
-    this.context.fillRect(this.x, this.y, this.width, this.height);
+    var img = new Image();
+    img.src = 'http://i.imgur.com/G1LkGk2.png';
+    this.context.drawImage(img, this.x, this.y, this.width, this.height);
   }
 };
 


### PR DESCRIPTION
- Add light colored stick figure image to Shooter draw function.
- Add light-green colored stick figure image to Target draw function.
- Update location of targets so stick figures aren't floating on the wall (had to make some obstacles thicker).

**TO-DO:**
- [ ] Commented-out code in `shooter.js` is there for if/when we add the moving arm functionality to the shooter. 
