### PR TITLE
Close #9 #10 #11. End level & calculate score

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,11 @@ var getClickPosition = require('./helpers');
 var Bullet = require('./bullet');
 var Shooter = require('./shooter');
 var shooter = new Shooter(context);
+var Scoreboard = require('./scoreboard');
+var scoreboard = new Scoreboard(context);
 var LevelOne = require('./level_one');
 
 var bullets = [];
-var ammo = 5;
 var level = 1;
 
 if (level === 1) { var currentLevel = new LevelOne(context); }
@@ -20,9 +21,9 @@ canvas.addEventListener('click', function (target) {
   var directionX = Math.cos(angleRadians) * 14;
   var directionY = Math.sin(angleRadians) * 14;
 
-  if (bullets.length === 0 && ammo > 0) {
+  if (currentLevel.ammo > 0 && scoreboard.targetsLeft > 0) {
     bullets.push(new Bullet(directionX, directionY, context));
-    ammo--;
+    currentLevel.ammo--;
   }
 });
 
@@ -30,6 +31,7 @@ requestAnimationFrame(function gameLoop() {
   context.clearRect(0, 0, canvas.width, canvas.height);
   shooter.draw();
   currentLevel.draw();
+  scoreboard.draw(currentLevel, bullets);
   bullets.forEach(function (bullet) {
     if (bullet.bounceCount < 8) {
       bullet.draw().move(currentLevel);

--- a/lib/level_one.js
+++ b/lib/level_one.js
@@ -10,7 +10,7 @@ function LevelOne(context){
   var targetLeft = new Target(0, 150, context);
   var targetMid = new Target(650, 150, context);
   this.context = context;
-  this.score = 0;
+  this.ammo = 5;
   this.targets = [targetRight, targetLeft, targetMid];
   this.obstacles = [obstacleMidVert, obstacleMidHoriz, obstacleEdgeVert, obstacleEdgeHoriz];
 }

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -48,10 +48,10 @@ function gameWinText(currentLevel, that) {
 
 
 function gameLoseText(currentLevel, that) {
-  this.context.font="40px Verdana";
-  this.context.fillStyle = "#6b111b";
-  this.context.textAlign="center";
-  this.context.fillText("YOU RAN OUT OF AMMO. PLEASE TRY AGAIN.", this.context.canvas.width/2, 60);
+  that.context.font="40px Verdana";
+  that.context.fillStyle = "#6b111b";
+  that.context.textAlign="center";
+  that.context.fillText("YOU RAN OUT OF AMMO. PLEASE TRY AGAIN.", that.context.canvas.width/2, 60);
 
   return that;
 }

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -1,0 +1,75 @@
+function Scoreboard(context) {
+  this.targetsLeft = 0;
+  this.context = context;
+}
+
+
+Scoreboard.prototype.draw = function (currentLevel, bullets) {
+  this.score(currentLevel);
+  this.getText(currentLevel, bullets);
+};
+
+
+Scoreboard.prototype.score = function(currentLevel) {
+  var killCount = 0;
+
+  currentLevel.targets.forEach(function(target) {
+    if (!target.display) { killCount++; }
+  });
+
+  this.targetsLeft = currentLevel.targets.length - killCount;
+};
+
+
+Scoreboard.prototype.getText = function (currentLevel, bullets) {
+  if(this.targetsLeft === 0) {
+    // if game won
+    gameWinText(currentLevel, this);
+  } else if(currentLevel.ammo === 0 && bullets.length === 0) {
+    // if game lost
+    gameLoseText(currentLevel, this);
+  } else {
+    // if game in progress
+    gameText(currentLevel, this);
+  }
+
+  return this;
+};
+
+
+function gameWinText(currentLevel, that) {
+  that.context.font="35px Verdana";
+  that.context.fillStyle = "white";
+  that.context.textAlign="center";
+  that.context.fillText("Score: " + (100 + currentLevel.ammo*100), that.context.canvas.width/2, 60);
+
+  return that;
+}
+
+
+function gameLoseText(currentLevel, that) {
+  this.context.font="40px Verdana";
+  this.context.fillStyle = "#6b111b";
+  this.context.textAlign="center";
+  this.context.fillText("YOU RAN OUT OF AMMO. PLEASE TRY AGAIN.", this.context.canvas.width/2, 60);
+
+  return that;
+}
+
+
+function gameText(currentLevel, that) {
+  that.context.font="14px Verdana";
+  that.context.fillStyle = "white";
+  that.context.beginPath();
+  that.context.textAlign="left";
+  that.context.fillText("Targets Remaining: " + that.targetsLeft, 10, 20);
+  that.context.closePath();
+
+  that.context.beginPath();
+  that.context.textAlign="right";
+  that.context.fillText("Shots Remaining: " + currentLevel.ammo, 1090, 20);
+
+  return that;
+}
+
+module.exports = Scoreboard;


### PR DESCRIPTION
- Add scoreboard
- Add `targetsLeft` counter to scoreboard to track number of targets remaining
- Add `draw` function to scoreboard to display game info on canvas during game or results info when level ends
- Move `ammo` to levels so that it can be changed for each level
